### PR TITLE
Add schedule trigger, daily at 6AM

### DIFF
--- a/.github/workflows/build-openjfx-mac.yml
+++ b/.github/workflows/build-openjfx-mac.yml
@@ -1,6 +1,8 @@
 name: Build OpenJFX on MacOS
 
 on:
+  schedule:
+    - cron: '0 6 * * *' # run at 6 AM UTC
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/build-openjfx-win.yml
+++ b/.github/workflows/build-openjfx-win.yml
@@ -1,6 +1,8 @@
 name: Build OpenJFX on Windows
 
 on:
+  schedule:
+    - cron: '0 6 * * *' # run at 6 AM UTC
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/build-openjfx.yml
+++ b/.github/workflows/build-openjfx.yml
@@ -1,6 +1,8 @@
 name: Build OpenJFX
 
 on:
+  schedule:
+    - cron: '0 6 * * *' # run at 6 AM UTC
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Adds a schedule trigger to the GitHub Actions workflows to run the builds daily at 6AM.

Fixes #25